### PR TITLE
Admin logout fix

### DIFF
--- a/djangooidc/views.py
+++ b/djangooidc/views.py
@@ -66,7 +66,7 @@ def authz_cb(request):
 
 
 def logout(request, next_page=None):
-    if not "op" in request.session.keys():
+    if not "op" in request.session.keys() or not "access_token" in request.session.keys():  # let's assume this is staff user
         return auth_logout_view(request, next_page='/')
 
     client = get_client()[request.session["op"]]


### PR DESCRIPTION
When admin logs out, in request.session there are no keys `op` and `access_token`

```
2019-04-18 10:56:07,473 ERROR 24704 [django.request] base.py:256 - Internal Server Error: /openid/logout
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 145, in inner
    return func(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/src/django-oidc/djangooidc/views.py", line 113, in logout
    'id_token_hint': request.session['access_token'],
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/sessions/backends/base.py", line 48, in __getitem__
    return self._session[key]
KeyError: 'access_token'
```